### PR TITLE
Increasing allocated memory and walltime requirements due to repeated…

### DIFF
--- a/config/cluster_config.yaml
+++ b/config/cluster_config.yaml
@@ -61,8 +61,9 @@ create_bam_mm_unique:
     time: 04-00:00:00
 
 merge_splits_unique_mm:
-    mem: 270g
-    time: 02-00:00:00
+    mem: 512g
+    time: 02-06:00:00
+    partition: largemem
 
 merge_mm_and_unique:
     threads: 2


### PR DESCRIPTION
**Message relayed to Marco from HPC staff**

> Your Biowulf jobs have caused 159 memory kills amongst 2 jobs on the cluster in the last hour. These are the result of jobs that attempt to use more memory than was allocated to the job. In addition to the wasted compute resources, these frequent out of memory kills can destabilize nodes and shared file systems and therefore affect other user's jobs.
> Here are some of the jobs:
> ```
> 27881930
> 27884157
> ```

