### PR TITLE
Adding Dockerfile for custom iCLIP version

### DIFF
--- a/.tests/cluster_config.yaml
+++ b/.tests/cluster_config.yaml
@@ -1,0 +1,126 @@
+# cluster configuration
+__default__:
+    gres: lscratch:96
+    mem: 40g
+    partition: norm
+    time: 00-02:00:00
+    threads: 32
+    output: .%j.{wildcards}.out
+    error: .%j.{wildcards}.err
+
+qc_barcode:
+    threads: 3
+    mem: 3g
+    time: 00-04:00:00
+
+demultiplex:
+    threads: 3
+    mem: 3g
+    time: 04-00:00:00
+
+remove_adaptors:
+    threads: 3
+    time: 1-00:00:00
+    mem: 3g
+
+qc_fastq_pre:
+    threads: 3
+    mem: 3g
+    time: 00-03:00:00
+
+qc_fastq_post:
+    threads: 3
+    mem: 3g
+    time: 00-03:00:00
+
+qc_screen_validator:
+    mem: 15g
+    time: 00-03:00:00
+
+split_files:
+    threads: 3
+    mem: 3g
+    time: 00-03:00:00
+
+novoalign:
+    mem: 50g
+    time: 10-00:00:00
+
+cleanup_conversion:
+    threads: 5
+    mem: 30g
+    time: 00-3:00:00
+
+merge_unmapped_splits:
+    time: 01-00:00:00
+    mem: 75g
+
+create_bam_mm_unique:
+    threads: 6
+    gres: lscratch:256
+    mem: 30g
+    time: 04-00:00:00
+
+merge_splits_unique_mm:
+    mem: 512g
+    time: 02-06:00:00
+    partition: largemem
+
+merge_mm_and_unique:
+    threads: 2
+    gres: lscratch:256
+    mem: 5g
+    time: 02-00:00:00
+
+qc_alignment:
+    mem: 10g
+
+qc_troubleshoot:
+    threads: 3
+    mem: 3g
+
+dedup:
+    threads: 2
+    mem: 64g
+    gres: lscratch:256
+    time: 01-00:00:00
+
+create_beds_safs:
+    mem: 350g
+    gres: lscratch:256
+    threads: 4
+    partition: largemem
+
+project_annotations:
+    threads: 2
+    mem: 10g
+    time: 00-01:00:00
+
+peak_annotations:
+    threads: 3
+    gres: lscratch:128
+    mem: 30g
+    time: 00-12:00:00
+
+annotation_report:
+    mem: 10g
+
+MANORM_analysis:
+    threads: 4
+    mem: 30g
+
+MANORM_post_processing:
+    threads: 2
+    mem: 2g
+    time: 00-01:00:00
+
+MANORM_RMD:
+    threads: 2
+    mem: 3g
+    time: 00-01:00:00
+
+mapq_recalc:
+    mem: 1TB
+    gres: lscratch:256
+    partition: largemem
+    time: 00-06:00:00

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,39 @@
+## Steps for Building Docker Images
+
+Directly below are instructions for building an image using the provided Dockerfile:
+
+```bash
+# See listing of images on computer
+docker image ls
+
+# Build from Dockerfile
+docker build --no-cache -f example.dockerfile --tag=ccbr_example:v0.1.0 .
+
+# Testing, take a peek inside
+docker run -ti ccbr_example:v0.1.0 /bin/bash
+
+# Updating Tag  before pushing to DockerHub
+docker tag ccbr_example:v0.1.0 skchronicles/ccbr_example:v0.1.0
+docker tag ccbr_example:v0.1.0 skchronicles/ccbr_example         # latest
+docker tag ccbr_example:v0.1.0 nciccbr/ccbr_example:v0.1.0
+docker tag ccbr_example:v0.1.0 nciccbr/ccbr_example              # latest
+
+# Check out new tag(s)
+docker image ls
+
+# Push new tagged image to DockerHub
+docker push skchronicles/ccbr_example:v0.1.0
+docker push skchronicles/ccbr_example:latest
+docker push nciccbr/ccbr_example:v0.1.0
+docker push nciccbr/ccbr_example:latest 
+```
+
+### Other Recommended Steps
+
+Scan your image for known vulnerabilities:
+
+```bash
+docker scan ccbr_example:v0.1.0
+```
+
+> **Please Note**: Any references to `skchronicles` should be replaced your username if you would also like to push the image to a non-org account.

--- a/docker/iCount/Dockerfile
+++ b/docker/iCount/Dockerfile
@@ -1,0 +1,133 @@
+# Custom version of iCount which contains an 
+# extra option to ultilize multiple threads 
+# in demultiplex and cutadapt sub commands:
+# https://github.com/skchronicles/iCount
+FROM ubuntu:18.04
+
+LABEL maintainer=kuhnsa@nih.gov
+
+# Create Container filesystem specific 
+# working directory and opt directories
+USER root
+RUN mkdir -p /opt2 && mkdir -p /data2
+WORKDIR /opt2 
+
+# Set time zone to US east coast 
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
+    && echo $TZ > /etc/timezone
+
+# This section installs system 
+# packages required for your 
+# project. If you need extra 
+# system packages add them here.
+# iCount requires argparse 
+# python package. Installs 
+# python/3.6, which includes 
+# argparse by default.
+# A child python dependency 
+# called 'Pillow', relies
+# on the following external
+# apt-get dependencies:
+# https://pillow.readthedocs.io/en/latest/installation.html#building-on-linux
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        build-essential \
+        gfortran \
+        git \
+        g++ \
+        make \
+        libtiff5-dev \
+        libjpeg8-dev \
+        libopenjp2-7-dev \
+        libfreetype6-dev \
+        liblcms2-dev \
+        libwebp-dev \
+        libharfbuzz-dev \
+        libfribidi-dev \
+        libxcb1-dev \
+        libatlas-base-dev \
+        libncurses5-dev \
+        libncursesw5-dev \
+        libssl-dev \
+        libcurl4-gnutls-dev \
+        liblzma-dev \
+        libbz2-dev \
+        pigz \
+        python \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-setuptools \
+        python3-tk \
+        pandoc \
+        tcl8.6-dev \
+        tk8.6-dev \
+        wget \
+        zlib1g-dev \
+    && apt-get clean && apt-get purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install htslib/1.10
+RUN wget https://github.com/samtools/htslib/releases/download/1.10/htslib-1.10.tar.bz2 \
+    && tar -vxjf htslib-1.10.tar.bz2 \
+    && rm htslib-1.10.tar.bz2 \
+    && cd htslib-1.10 \
+    && make \
+    && cd /opt2
+
+# Install samtools/1.10
+RUN wget https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2 \
+    && tar -vxjf samtools-1.10.tar.bz2 \
+    && rm samtools-1.10.tar.bz2 \
+    && cd samtools-1.10 \
+    && make \
+    && cd /opt2
+
+# Install BEDTools
+# Requires version>=2.26, where
+# merge command reports strand
+# Also, requires python (already 
+# satified) to build from source 
+RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.27.1/bedtools-2.27.1.tar.gz \
+    && tar -xvf bedtools-2.27.1.tar.gz \
+    && rm bedtools-2.27.1.tar.gz \
+    && cd bedtools2/ \
+    && make \
+    && make install \
+    && cd /opt2
+
+# Install STAR
+RUN wget https://github.com/alexdobin/STAR/archive/2.6.1a.tar.gz \
+    && tar -xvzf 2.6.1a.tar.gz \
+    && rm 2.6.1a.tar.gz \
+    && cd STAR-2.6.1a/source/ \
+    && make STAR \
+    && cd /opt2
+
+# Install custom version of iCount
+# includes multithreading changes
+# demultiplex and cutadapt subcmds.
+# The output from the custom version 
+# and the orignial version should 
+# produce identical output. 
+# The changes that have been made
+# should only effect runtime, (i.e.
+# it should be significantly faster).
+RUN pip3 install numpy pandas pysam pybedtools numpydoc matplotlib
+RUN git clone https://github.com/skchronicles/iCount.git \
+    && cd iCount/ \
+    && pip3 install .[docs,test] \
+    && cd /opt2
+
+# Add Dockerfile to container FS
+# and export environment variables
+# and ensure proper permissions
+ADD Dockerfile /opt2/Dockerfile
+RUN chmod -R a+rX /opt2 \
+    && ln -sf /usr/bin/python3 /usr/bin/python
+ENV PATH="$PATH:/opt2/samtools-1.10:/opt2/htslib-1.10:/opt2/STAR-2.6.1a/source"
+
+# Reset working directory
+WORKDIR /data2

--- a/docker/iCount/build.sh
+++ b/docker/iCount/build.sh
@@ -1,0 +1,14 @@
+# Build image
+docker build --no-cache -f Dockerfile --tag=ccbr_icount:v1.0.0 .
+
+# Tag image with version and reset latest
+docker tag ccbr_icount:v1.0.0 skchronicles/ccbr_icount:v1.0.0
+docker tag ccbr_icount:v1.0.0 skchronicles/ccbr_icount
+docker tag ccbr_icount:v1.0.0 nciccbr/ccbr_icount:v1.0.0
+docker tag ccbr_icount:v1.0.0 nciccbr/ccbr_icount
+
+# Push image to DockerHub
+docker push skchronicles/ccbr_icount:v1.0.0
+docker push skchronicles/ccbr_icount:latest
+docker push nciccbr/ccbr_icount:v1.0.0
+docker push nciccbr/ccbr_icount:latest


### PR DESCRIPTION
### Dockerfile for custom iCLIP version

**About**
Cutadapt versions greater than or equal to 1.15 support multithreading, adding an option to run cutadapt in this mode.

**Changes**
Changes
This option is only enabled if the version of cutadapt in the user's PATH is greater than or equal to 1.15. Under the hood, I am checking for compatibility with the minimum version of cutadapt that is supported against the version of cutadapt in the user's path. If the version of cutadapt that is install does not support the -j option, then it is not provided at command line (i.e. meaning it will run the same as before).

**Resources**
- Github:  https://github.com/skchronicles/iCount
- Dockerhub: https://hub.docker.com/repository/docker/nciccbr/ccbr_icount